### PR TITLE
Enable using smaller dbs in staging and development

### DIFF
--- a/application-boundary.tf
+++ b/application-boundary.tf
@@ -6,11 +6,12 @@ data "cloudfoundry_space" "broker_space" {
 module "broker_smtp" {
   source = "./broker"
 
-  name                  = "ssb-smtp"
+  name                  = "${var.name_prefix}-smtp"
   path                  = "./app-smtp"
   broker_space          = var.broker_space
   client_spaces         = var.client_spaces
   enable_ssh            = var.enable_ssh
+  broker_db_plan_name   = var.broker_db_plan_name
   aws_access_key_id     = module.ssb-smtp-broker-user.iam_access_key_id
   aws_secret_access_key = module.ssb-smtp-broker-user.iam_access_key_secret
   aws_region            = var.aws_target_region

--- a/broker/main.tf
+++ b/broker/main.tf
@@ -10,7 +10,7 @@ data "cloudfoundry_service" "rds" {
 resource "cloudfoundry_service_instance" "db" {
   name         = "${var.name}-db"
   space        = data.cloudfoundry_space.broker_space.id
-  service_plan = data.cloudfoundry_service.rds.service_plans["small-mysql-redundant"]
+  service_plan = data.cloudfoundry_service.rds.service_plans[var.broker_db_plan_name]
   tags         = ["mysql"]
   lifecycle {
     prevent_destroy = true

--- a/broker/vars.tf
+++ b/broker/vars.tf
@@ -54,6 +54,11 @@ variable "enable_ssh" {
   description = "Whether `cf ssh` should be enabled for the broker app"
 }
 
+variable "broker_db_plan_name" {
+  default     = "small-mysql"
+  description = "DB plan name for the broker app"
+}
+
 variable "aws_access_key_id" {
   description = "AWS access key to use for managing resources. Policy requirements: https://github.com/pivotal/cloud-service-broker/blob/master/docs/aws-installation.md#required-iam-policies"
   default     = ""

--- a/terraform.development.tfvars
+++ b/terraform.development.tfvars
@@ -8,4 +8,5 @@ broker_space = {
 }
 broker_zone       = "notify-dev.rcahearn.net"
 manage_zone       = true
+name_prefix       = "ssb-devel"
 aws_target_region = "us-west-2"

--- a/terraform.production.tfvars
+++ b/terraform.production.tfvars
@@ -6,7 +6,8 @@ broker_space = {
   org   = "gsa-tts-benefits-studio-prototyping"
   space = "notify-management"
 }
-broker_zone       = "ssb.notify.gov"
-manage_zone       = false
-enable_ssh        = false
-aws_target_region = "us-gov-west-1"
+broker_zone         = "ssb.notify.gov"
+manage_zone         = false
+enable_ssh          = false
+broker_db_plan_name = "small-mysql-redundant"
+aws_target_region   = "us-gov-west-1"

--- a/vars.tf
+++ b/vars.tf
@@ -68,3 +68,13 @@ variable "enable_ssh" {
   default     = true
   description = "Whether `cf ssh` should be enabled for the broker app"
 }
+
+variable "broker_db_plan_name" {
+  default     = "small-mysql"
+  description = "DB plan name for the broker app"
+}
+
+variable "name_prefix" {
+  default     = "ssb"
+  description = "Prefix for infrastructure names, to aid in deduplication"
+}


### PR DESCRIPTION
Also enables setting a name prefix, so that multiple brokers can be registered in the sandbox space.