### PR TITLE
Revert temporary workaround

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -17,8 +17,6 @@ env:
 jobs:
 
   apply-staging:
-    needs: apply-production
-
     name: apply (staging)
     runs-on: ubuntu-latest
     environment: staging
@@ -59,7 +57,7 @@ jobs:
         run: echo staging tests ok  # TODO staging smoke tests
 
   apply-production:
-    # needs: apply-staging
+    needs: apply-staging
 
     name: apply (production)
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reverts "Temporarily run production before staging to free up broker name"

This reverts commit c71028a5e0bf6bf47e269561ccd39c260d5fe8e8.