### PR TITLE
Add restage apps workflow

### DIFF
--- a/.github/workflows/restage-apps.yml
+++ b/.github/workflows/restage-apps.yml
@@ -1,0 +1,46 @@
+---
+name: Restage apps
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Which environment needs to be restaged"
+        required: true
+        default: staging
+        type: environment
+
+jobs:
+  restage_development:
+    runs-on: ubuntu-latest
+    if: inputs.environment == 'development'
+    environment: development
+    strategy:
+      matrix:
+        app: ["sms", "smtp"]
+    steps:
+      - name: Restage devel ${{matrix.app}}
+        uses: 18f/cg-deploy-action@main
+        with:
+          cf_username: ${{ secrets.TF_VAR_cf_username }}
+          cf_password: ${{ secrets.TF_VAR_cf_password }}
+          cf_org: gsa-tts-benefits-studio-prototyping
+          cf_space: notify-sandbox
+          full_command: "cf restage --strategy rolling ssb-devel-${{matrix.app}}"
+
+  restage_ssb:
+    runs-on: ubuntu-latest
+    if: inputs.environment != 'development'
+    environment: ${{ inputs.environment }}
+    strategy:
+      matrix:
+        app: ["sms", "smtp"]
+    steps:
+      - name: Restage ${{matrix.app}}
+        uses: 18f/cg-deploy-action@main
+        with:
+          cf_username: ${{ secrets.TF_VAR_cf_username }}
+          cf_password: ${{ secrets.TF_VAR_cf_password }}
+          cf_org: gsa-tts-benefits-studio-prototyping
+          cf_space: ${{ inputs.environment == 'production' && 'notify-management' || 'notify-management-staging' }}
+          full_command: "cf restage --strategy rolling ssb-${{matrix.app}}"

--- a/terraform.production.tfvars
+++ b/terraform.production.tfvars
@@ -1,6 +1,6 @@
 # See vars.tf for more information
 client_spaces = {
-  gsa-tts-benefits-studio-prototyping = ["notify-management", "notify-prod"]
+  gsa-tts-benefits-studio-prototyping = ["notify-management", "notify-production"]
 }
 broker_space = {
   org   = "gsa-tts-benefits-studio-prototyping"


### PR DESCRIPTION
* Add a manually-run workflow to restage the ssb apps
* Update `notify-prod` to `notify-production` for prod SSB

Work towards https://github.com/GSA/notifications-api/issues/203