### PR TITLE
Update SSB deployment details

### DIFF
--- a/app-setup-sms.sh
+++ b/app-setup-sms.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-CSB_VERSION="v0.15.0"
+CSB_VERSION="v0.17.10"
 SMS_BROKERPAK_VERSION="v2.0.1"
 
 # Set up an app dir and bin dir

--- a/app-setup-smtp.sh
+++ b/app-setup-smtp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-CSB_VERSION="v0.15.0"
+CSB_VERSION="v0.17.10"
 SMTP_BROKERPAK_VERSION="v2.0.0"
 
 # Set up an app dir and bin dir

--- a/broker/main.tf
+++ b/broker/main.tf
@@ -34,11 +34,16 @@ data "archive_file" "app_zip" {
   output_path = "./app-${var.name}.zip"
 }
 
+data "cloudfoundry_stack" "cflinuxfs4" {
+  name = "cflinuxfs4"
+}
+
 resource "cloudfoundry_app" "ssb" {
   space            = data.cloudfoundry_space.broker_space.id
   name             = var.name
   path             = data.archive_file.app_zip.output_path
   buildpack        = "binary_buildpack"
+  stack            = data.cloudfoundry_stack.cflinuxfs4.id
   command          = var.command
   instances        = var.instances
   memory           = var.memory


### PR DESCRIPTION
* Updates base cloud-service-broker from 0.15.0 to most recent 0.17.10 release
* Updates cloud.gov stack to cflinuxfs4

work towards https://github.com/GSA/notifications-api/issues/220