### PR TITLE
Use rolling deploy strategy

### DIFF
--- a/broker/main.tf
+++ b/broker/main.tf
@@ -50,7 +50,7 @@ resource "cloudfoundry_app" "ssb" {
   disk_quota       = var.disk
   enable_ssh       = var.enable_ssh
   source_code_hash = data.archive_file.app_zip.output_base64sha256
-  strategy         = "blue-green"
+  strategy         = "rolling"
   service_binding {
     service_instance = cloudfoundry_service_instance.db.id
   }

--- a/broker/versions.tf
+++ b/broker/versions.tf
@@ -5,7 +5,7 @@ terraform {
     }
     cloudfoundry = {
       source  = "registry.terraform.io/cloudfoundry-community/cloudfoundry"
-      version = "~> 0.14.0"
+      version = "~> 0.50.7"
     }
     random = {
       source = "hashicorp/random"

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     cloudfoundry = {
       source  = "registry.terraform.io/cloudfoundry-community/cloudfoundry"
-      version = "~> 0.14.0"
+      version = "~> 0.50.7"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
With blue-green, a transient deploy error can cause a permanent deploy error due to how the terraform actions enforce the apply actions being equal to the plan actions in the PR.

Rolling should both use less memory overall, and allow us to re-try a deploy in the case of a transient error.