### PR TITLE
Switch broker domain to ssb.notify.gov

### DIFF
--- a/terraform.development.tfvars
+++ b/terraform.development.tfvars
@@ -6,7 +6,7 @@ broker_space = {
   org   = "gsa-tts-benefits-studio-prototyping"
   space = "notify-sandbox"
 }
-broker_zone       = "notify-dev.rcahearn.net"
+broker_zone       = "dev.ssb.notify.gov"
 manage_zone       = true
 name_prefix       = "ssb-devel"
 aws_target_region = "us-west-2"

--- a/terraform.staging.tfvars
+++ b/terraform.staging.tfvars
@@ -6,6 +6,6 @@ broker_space = {
   org   = "gsa-tts-benefits-studio-prototyping"
   space = "notify-management-staging"
 }
-broker_zone       = "notify-staging.rcahearn.net"
+broker_zone       = "ssb.notify.gov"
 manage_zone       = true
 aws_target_region = "us-west-2"


### PR DESCRIPTION
Before merging this:

- [x] delete `notify-api-ses-staging` service in `notify-staging` space. This will disable email in staging and all developer environments until set back up.

After merging this, see tasks in https://github.com/GSA/notifications-api/issues/263