### PR TITLE
Remove `-prototyping` from org name

### DIFF
--- a/.github/workflows/restage-apps.yml
+++ b/.github/workflows/restage-apps.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           cf_username: ${{ secrets.TF_VAR_cf_username }}
           cf_password: ${{ secrets.TF_VAR_cf_password }}
-          cf_org: gsa-tts-benefits-studio-prototyping
+          cf_org: gsa-tts-benefits-studio
           cf_space: notify-sandbox
           full_command: "cf restage --strategy rolling ssb-devel-${{matrix.app}}"
 
@@ -41,6 +41,6 @@ jobs:
         with:
           cf_username: ${{ secrets.TF_VAR_cf_username }}
           cf_password: ${{ secrets.TF_VAR_cf_password }}
-          cf_org: gsa-tts-benefits-studio-prototyping
+          cf_org: gsa-tts-benefits-studio
           cf_space: ${{ inputs.environment == 'production' && 'notify-management' || 'notify-management-staging' }}
           full_command: "cf restage --strategy rolling ssb-${{matrix.app}}"

--- a/terraform.development.tfvars
+++ b/terraform.development.tfvars
@@ -1,9 +1,9 @@
 # See vars.tf for more information
 client_spaces = {
-  gsa-tts-benefits-studio-prototyping = ["notify-sandbox"]
+  gsa-tts-benefits-studio = ["notify-sandbox"]
 }
 broker_space = {
-  org   = "gsa-tts-benefits-studio-prototyping"
+  org   = "gsa-tts-benefits-studio"
   space = "notify-sandbox"
 }
 broker_zone       = "dev.ssb.notify.gov"

--- a/terraform.production.tfvars
+++ b/terraform.production.tfvars
@@ -1,9 +1,9 @@
 # See vars.tf for more information
 client_spaces = {
-  gsa-tts-benefits-studio-prototyping = ["notify-management", "notify-production"]
+  gsa-tts-benefits-studio = ["notify-management", "notify-production"]
 }
 broker_space = {
-  org   = "gsa-tts-benefits-studio-prototyping"
+  org   = "gsa-tts-benefits-studio"
   space = "notify-management"
 }
 broker_zone         = "ssb.notify.gov"

--- a/terraform.staging.tfvars
+++ b/terraform.staging.tfvars
@@ -1,9 +1,9 @@
 # See vars.tf for more information
 client_spaces = {
-  gsa-tts-benefits-studio-prototyping = ["notify-management-staging", "notify-demo", "notify-staging", "notify-sandbox"]
+  gsa-tts-benefits-studio = ["notify-management-staging", "notify-demo", "notify-staging", "notify-sandbox"]
 }
 broker_space = {
-  org   = "gsa-tts-benefits-studio-prototyping"
+  org   = "gsa-tts-benefits-studio"
   space = "notify-management-staging"
 }
 broker_zone       = "ssb.notify.gov"


### PR DESCRIPTION
Project org has been renamed from `gsa-tts-benefits-studio-prototyping` to `gsa-tts-benefits-studio`. Update the workflow to match.