### PR TITLE
Replace org name with GUID

### DIFF
--- a/broker/main.tf
+++ b/broker/main.tf
@@ -1,6 +1,6 @@
 data "cloudfoundry_space" "broker_space" {
-  name     = var.broker_space.space
-  org_name = var.broker_space.org
+  name  = var.broker_space.space
+  org = "9e428562-a2d9-41b4-9c23-1ef5237fb44e" # gsa-tts-benefits-studio
 }
 
 data "cloudfoundry_service" "rds" {

--- a/broker/main.tf
+++ b/broker/main.tf
@@ -1,6 +1,6 @@
 data "cloudfoundry_space" "broker_space" {
-  name  = var.broker_space.space
-  org = "9e428562-a2d9-41b4-9c23-1ef5237fb44e" # gsa-tts-benefits-studio
+  name = var.broker_space.space
+  org  = "9e428562-a2d9-41b4-9c23-1ef5237fb44e" # gsa-tts-benefits-studio
 }
 
 data "cloudfoundry_service" "rds" {


### PR DESCRIPTION
Replace `org_name` argument with `org` and GUID. An experiment, to see if CI/CD gets less confused about which org we're working with.