### PR TITLE
Terraform version upgrade

### DIFF
--- a/broker/versions.tf
+++ b/broker/versions.tf
@@ -11,5 +11,5 @@ terraform {
       source = "hashicorp/random"
     }
   }
-  required_version = ">= 0.13"
+  required_version = "~> 1.0"
 }


### PR DESCRIPTION
Increase Terraform minimum required version from 0.13 to 1.0, [the minimum used by ttsnotify-brokerpak-sms](https://github.com/GSA/ttsnotify-brokerpak-sms/blob/8714d7f2fb402fa0287af6e1a8770a47700a1bcc/permission-policies.tf#L5).