### PR TITLE
Move brokers

### DIFF
--- a/broker/moves.tf
+++ b/broker/moves.tf
@@ -1,0 +1,17 @@
+# Items renamed when "prototyping" was dropped from the org name
+moved {
+  from = cloudfoundry_service_broker.space_scoped_broker["gsa-tts-benefits-studio-prototyping/notify-staging"]
+  to   = cloudfoundry_service_broker.space_scoped_broker["gsa-tts-benefits-studio/notify-staging"]
+}
+moved {
+  from = cloudfoundry_service_broker.space_scoped_broker["gsa-tts-benefits-studio-prototyping/notify-demo"]
+  to   = cloudfoundry_service_broker.space_scoped_broker["gsa-tts-benefits-studio/notify-demo"]
+}
+moved {
+  from = cloudfoundry_service_broker.space_scoped_broker["gsa-tts-benefits-studio-prototyping/notify-management"]
+  to   = cloudfoundry_service_broker.space_scoped_broker["gsa-tts-benefits-studio/notify-management"]
+}
+moved {
+  from = cloudfoundry_service_broker.space_scoped_broker["gsa-tts-benefits-studio-prototyping/notify-production"]
+  to   = cloudfoundry_service_broker.space_scoped_broker["gsa-tts-benefits-studio/notify-production"]
+}


### PR DESCRIPTION
Note that each space-scoped broker that had "prototyping" in the name corresponds to one with an updated name. This is a bit of clean-up after the rename of the org. It is experimental.

The code uses the `moved` block in a for_each loop, which [updates instance keys](https://developer.hashicorp.com/terraform/language/modules/develop/refactoring#enabling-count-or-for_each-for-a-resource) that have changed.