### PR TITLE
Upgrade CSB to v0.22.2

### DIFF
--- a/app-setup-sms.sh
+++ b/app-setup-sms.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-CSB_VERSION="v0.17.10"
+CSB_VERSION="v0.22.2"
 SMS_BROKERPAK_VERSION="v2.1.1"
 
 # Set up an app dir and bin dir

--- a/app-setup-smtp.sh
+++ b/app-setup-smtp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-CSB_VERSION="v0.17.10"
+CSB_VERSION="v0.22.2"
 SMTP_BROKERPAK_VERSION="v2.0.0"
 
 # Set up an app dir and bin dir


### PR DESCRIPTION
After [rolling back](https://github.com/GSA/usnotify-ssb/pull/28) a previous [Cloud Service Broker](https://github.com/cloudfoundry/cloud-service-broker/tree/main) upgrade to v2.1.1, upgrade instead (for now) to v0.22.2, the last that does not use OpenTofu